### PR TITLE
Get page from event payload on page click

### DIFF
--- a/docs/.vuepress/components/TextInputCustomPage.vue
+++ b/docs/.vuepress/components/TextInputCustomPage.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <input
+      v-if="isCurrent"
+      type="text"
+      v-model="pageInput"
+      class="page-input"
+      :aria-label="ariaPageLabel"
+      @change="jumpToPageInput"
+    ></ts-input>
+    <a
+      v-else
+      :class="pageClass"
+      href="#"
+      :aria-label="ariaPageLabel"
+      @click="goToPage"
+    >{{ page }}</a>
+  </div>
+</template>
+
+<style scoped>
+.page-input {
+  width: 20px;
+  font-size: 16px;
+  text-align: center;
+}
+</style>
+
+<script>
+export default {
+  name: 'TextInputCustomPage',
+  props: {
+    ariaPageLabel: {
+      type: String,
+      required: true
+    },
+    isCurrent: {
+      type: Boolean,
+      required: true
+    },
+    page: {
+      type: Number,
+      required: true
+    },
+    pageClass: {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      pageInput: this.page
+    };
+  },
+  methods: {
+    goToPage(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.$emit('page-click', this.page);
+    },
+    jumpToPageInput() {
+      this.$emit('page-click', parseInt(this.pageInput));
+    }
+  }
+};
+</script>

--- a/docs/.vuepress/components/WithCustomPage.vue
+++ b/docs/.vuepress/components/WithCustomPage.vue
@@ -1,0 +1,31 @@
+<template>
+  <sliding-pagination
+    pageComponent="text-input-custom-page"
+    :current="current"
+    :total="total"
+    @page-change="onPageChange"
+  >
+  </sliding-pagination>
+</template>
+
+<script>
+import SlidingPagination from '@/../../../src/SlidingPagination.vue'
+
+export default {
+  name: 'WithCustomPage',
+  components: {
+    SlidingPagination
+  },
+  data() {
+    return {
+      current: 1,
+      total: 20
+    }
+  },
+  methods: {
+    onPageChange (page) {
+      this.current = page
+    }
+  }
+}
+</script>

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,3 +7,12 @@ Easy as 1-2-3. :tada:
 <simple-example></simple-example>
 
 <<< @/.vuepress/components/SimpleExample.vue
+
+## With Custom Page
+
+A custom page component that allows jumping to another page using a text input.
+
+<with-custom-page></with-custom-page>
+
+<<< @/.vuepress/components/TextInputCustomPage.vue
+<<< @/.vuepress/components/WithCustomPage.vue

--- a/src/SlidingPagination.vue
+++ b/src/SlidingPagination.vue
@@ -29,7 +29,7 @@
           :aria-page-label="pageLabel(page)"
           :page="page"
           :page-class="classMap.page"
-          @page-click="goToPage(page)"
+          @page-click="goToPage"
         />
       </li><!--
       --><li
@@ -56,7 +56,7 @@
           :aria-page-label="pageLabel(page)"
           :page="page"
           :page-class="classMap.page"
-          @page-click="goToPage(page)"
+          @page-click="goToPage"
         />
       </li><!--
       --><li
@@ -83,7 +83,7 @@
           :aria-page-label="pageLabel(page)"
           :page="page"
           :page-class="classMap.page"
-          @page-click="goToPage(page)"
+          @page-click="goToPage"
         />
       </li><!--
       --><li

--- a/test/unit/specs/SlidingPagination.spec.js
+++ b/test/unit/specs/SlidingPagination.spec.js
@@ -248,24 +248,36 @@ describe('SlidingPagination.vue', () => {
 })
 
 describe('SlidingPagination.vue-custom', () => {
-  it('supports replacing the default page component', () => {
-    const localVue = createLocalVue()
+  const localVue = createLocalVue()
 
-    localVue.component('TestPageComponent', {
-      name: 'TestPageComponent',
+  localVue.component('TestPageComponent', {
+    name: 'TestPageComponent',
 
-      props: {
-        page: {
-          type: Number,
-          required: true
-        }
-      },
-
-      render (h) {
-        return h('a', { class: 'test-page-component' }, 'Test Page ' + this.page)
+    props: {
+      page: {
+        type: Number,
+        required: true
       }
-    })
+    },
 
+    render (h) {
+      const self = this
+      return h(
+        'a',
+        {
+          class: `test-page-component-${this.page}`,
+          on: {
+            click: function () {
+              self.$emit('page-click', 42)
+            }
+          }
+        },
+        'Test Page ' + this.page
+      )
+    }
+  })
+
+  it('supports replacing the default page component', () => {
     const wrapper = mount(SlidingPagination, {
       localVue,
       propsData: {
@@ -275,6 +287,23 @@ describe('SlidingPagination.vue-custom', () => {
       }
     })
 
-    expect(wrapper.find('.test-page-component').text()).toBe('Test Page 1')
+    expect(wrapper.find('.test-page-component-1').text()).toBe('Test Page 1')
+  })
+
+  it('relies on page component arguments for changing page', () => {
+    const wrapper = mount(SlidingPagination, {
+      localVue,
+      propsData: {
+        current: 1,
+        total: 3,
+        pageComponent: 'TestPageComponent'
+      }
+    })
+
+    wrapper.find('.test-page-component-1').trigger('click')
+
+    expect(wrapper.emitted()['page-change']).toBeTruthy()
+    expect(wrapper.emitted()['page-change'].length).toBe(1)
+    expect(wrapper.emitted()['page-change'][0]).toEqual([42])
   })
 })


### PR DESCRIPTION
Right now the pagination component ignores the payload provided by the page component on page-click event. It just goes to the current page. This is fine for links but I have a use case where the current page component is a text input that allows jumping to a page other than the current one.

The default page component already provides the current page in the payload so this change has no impact on people using the library out of the box. The could be a regression in case of a custom page component that would rely on the fact that the payload used to be ignored.